### PR TITLE
fix: tools/annotate: Add JoynRide Authors to `ORG` variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 JoynRide Authors
+# SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 The JoynRide Authors
+SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 The JoynRide Authors
+SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2024 The JoynRide Authors
+# SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,9 +1,10 @@
 =======
+
 <!--
-   SPDX-FileCopyrightText: 2024 CCOS-USP <https://ccos.icmc.usp.br>
-   SPDX-FileCopyrightText: 2024 Monaco F. J. <monaco@usp.br>
-  
-   SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
+SPDX-FileCopyrightText: 2024 Monaco F. J. <monaco@usp.br>
+
+SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
 Contributing to JoynRide

--- a/serv/go.mod
+++ b/serv/go.mod
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 CCOS-USP <https://ccos.icmc.usp.br
+// SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/serv/serv.go
+++ b/serv/serv.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 CCOS-USP <https://ccos.icmc.usp.br
+// SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tools/annotate
+++ b/tools/annotate
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2024 CCOS-USP <https://ccos.icmc.usp.br
+# SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,7 +20,7 @@ fi
 user=$(git config user.name)
 email=$(git config user.email)
 license="GPL-3.0-or-later"
-ORG="CCOS-USP <https://ccos.icmc.usp.br"
+ORG="The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>"
 
 if ! test -f $filename; then
     printf "File '$filename' not found; create it? (y|N) "

--- a/tools/lint
+++ b/tools/lint
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2024 CCOS-USP <https://ccos.icmc.usp.br
+# SPDX-FileCopyrightText: 2024 The JoynRide Authors and CCOS-USP <https://ccos.icmc.usp.br>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
The `ORG` variable contains the organization name. It's lacking the JoynRide Authors. Add them to the variable and fix the licenses on the files.